### PR TITLE
docs: Update setup.md

### DIFF
--- a/docs/content/1.getting-started/1.setup.md
+++ b/docs/content/1.getting-started/1.setup.md
@@ -17,15 +17,23 @@ yarn add --dev @nuxtjs/tailwindcss
 npm install --save-dev @nuxtjs/tailwindcss
 ```
 
-::
+::code-group
 
 2. Add it to your `modules` section in your `nuxt.config`:
 
-```ts [nuxt.config]
+```ts [nuxt.config (Nuxt 2)]
 export default {
   modules: ['@nuxtjs/tailwindcss']
 }
 ```
+
+```ts [nuxt.config (Nuxt 3)]
+export default defineNuxtConfig{
+  modules: ['@nuxtjs/tailwindcss']
+}
+```
+
+
 
 3. Create your `tailwind.config.js` by running:
 


### PR DESCRIPTION
Hi.
Reviewing docs:  I read it as a setup for Nuxt 3 Tailwind, however the nuxt.config refers to the old 'export default' vs. the new direction.  Thus, suggesting stacking code boxes, with reference to the versions to load, as a possible solution?

ALSO... on the 'home page' for this site, it has an impage of the terminal with instructions.  That is great, however I'd also caption that image with 'See here for next steps', with hyper link to the next page.  I missread the home page last time I visited this site as 'that is all I needed to do'... I am very much a bigginner, thus the mistake.

Love your work.  You guys rock.

Thanks.  Nick