### PR TITLE
feat: add option to set `cssPath` to `false`

### DIFF
--- a/docs/content/1.getting-started/2.options.md
+++ b/docs/content/1.getting-started/2.options.md
@@ -42,15 +42,9 @@ export default {
   }
 }
 ```
+
 ::alert{type="warning"}
-
-If `cssPath` is set to `false`, HMR for tailwindcss will be broken.
-
-::
-::alert{type="warning"}
-
-If `cssPath` is set to `false`, HMR for tailwindcss will be broken.
-
+When set to `false`, note that HMR for tailwindcss will be broken (hard refresh needed).
 ::
 
 ## `configPath`

--- a/docs/content/1.getting-started/2.options.md
+++ b/docs/content/1.getting-started/2.options.md
@@ -42,7 +42,11 @@ export default {
   }
 }
 ```
+::alert{type="warning"}
 
+If `cssPath` is set to `false`, HMR for tailwindcss will be broken.
+
+::
 ::alert{type="warning"}
 
 If `cssPath` is set to `false`, HMR for tailwindcss will be broken.

--- a/docs/content/1.getting-started/2.options.md
+++ b/docs/content/1.getting-started/2.options.md
@@ -45,7 +45,7 @@ export default {
 
 ::alert{type="warning"}
 
-If 'cssPath' is set to 'false', HMR for tailwindcss will be broken.
+If `cssPath` is set to `false`, HMR for tailwindcss will be broken.
 
 ::
 

--- a/docs/content/1.getting-started/2.options.md
+++ b/docs/content/1.getting-started/2.options.md
@@ -33,6 +33,16 @@ export default {
 
 This file will be directly injected as a [global CSS](https://v3.nuxtjs.org/api/configuration/nuxt.config#css) for Nuxt. It supports `css`, `sass`, `postcss`, and more.
 
+If you don't want to inject CSS file, you can set `cssPath` to `false`.
+
+```ts [nuxt.config]
+export default {
+  tailwindcss: {
+    cssPath: false,
+  }
+}
+```
+
 ## `configPath`
 
 - Default: `'tailwind.config.js'`

--- a/docs/content/1.getting-started/2.options.md
+++ b/docs/content/1.getting-started/2.options.md
@@ -43,6 +43,12 @@ export default {
 }
 ```
 
+::alert{type="warning"}
+
+If 'cssPath' is set to 'false', HMR for tailwindcss will be broken.
+
+::
+
 ## `configPath`
 
 - Default: `'tailwind.config.js'`

--- a/src/module.ts
+++ b/src/module.ts
@@ -42,7 +42,7 @@ type Arrayable<T> = T | T[]
 
 export interface ModuleOptions {
   configPath: Arrayable<string>;
-  cssPath: string;
+  cssPath: string | false;
   config: Config;
   viewer: boolean;
   exposeConfig: boolean;
@@ -162,7 +162,7 @@ export default defineNuxtModule<ModuleOptions>({
      * CSS file handling
      */
 
-    const cssPath = await resolvePath(moduleOptions.cssPath, { extensions: ['.css', '.sass', '.scss', '.less', '.styl'] })
+    const cssPath = typeof moduleOptions.cssPath === 'string' ? await resolvePath(moduleOptions.cssPath, { extensions: ['.css', '.sass', '.scss', '.less', '.styl'] }) : false
 
     // Include CSS file in project css
     let resolvedCss: string
@@ -175,6 +175,9 @@ export default defineNuxtModule<ModuleOptions>({
         // @ts-ignore
         resolvedCss = createResolver(import.meta.url).resolve('runtime/tailwind.css')
       }
+    } else {
+      logger.info('No Tailwind CSS file found. Skipping...')
+      resolvedCss = createResolver(import.meta.url).resolve('runtime/empty.css')
     }
     nuxt.options.css = nuxt.options.css ?? []
     const resolvedNuxtCss = await Promise.all(nuxt.options.css.map(p => resolvePath(p)))


### PR DESCRIPTION
resolve #543 

If use `cssPath: false` option, tailwindcss path is unknown so Vite HMR is not available.