### PR TITLE
feat!: update viewer dev middleware to be compatible with `h3@0.8`

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "clear-module": "^4.1.2",
     "consola": "^2.15.3",
     "defu": "^6.1.0",
+    "h3": "^0.8.1",
     "postcss": "^8.4.16",
     "postcss-custom-properties": "^12.1.8",
     "postcss-nesting": "^10.1.10",

--- a/src/module.ts
+++ b/src/module.ts
@@ -15,6 +15,7 @@ import {
   isNuxt3, findPath, requireModule
 } from '@nuxt/kit'
 import { Config } from 'tailwindcss'
+import { eventHandler } from 'h3'
 import { name, version } from '../package.json'
 import vitePlugin from './hmr'
 import defaultTailwindConfig from './tailwind.config'
@@ -231,13 +232,13 @@ export default defineNuxtModule<ModuleOptions>({
       const { withTrailingSlash, withoutTrailingSlash } = await import('ufo')
       const routerPrefix = isNuxt3() ? route : undefined
       const _viewerDevMiddleware = createServer({ tailwindConfigProvider: () => tailwindConfig, routerPrefix }).asMiddleware()
-      const viewerDevMiddleware = (req, res) => {
-        if (req.originalUrl === withoutTrailingSlash(route)) {
-          res.writeHead(301, { Location: withTrailingSlash(req.originalUrl) })
-          return res.end()
+      const viewerDevMiddleware = eventHandler((event) => {
+        if (event.req.url === withoutTrailingSlash(route)) {
+          event.res.writeHead(301, { Location: withTrailingSlash(event.req.url) })
+          return event.res.end()
         }
-        _viewerDevMiddleware(req, res)
-      }
+        _viewerDevMiddleware(event.req, event.res)
+      })
       if (isNuxt3()) { addDevServerHandler({ route, handler: viewerDevMiddleware }) }
       if (isNuxt2()) { nuxt.options.serverMiddleware.push({ route, handler: viewerDevMiddleware }) }
       nuxt.hook('listen', (_, listener) => {

--- a/src/module.ts
+++ b/src/module.ts
@@ -15,7 +15,7 @@ import {
   isNuxt3, findPath, requireModule
 } from '@nuxt/kit'
 import { Config } from 'tailwindcss'
-import { eventHandler } from 'h3'
+import { eventHandler, sendRedirect } from 'h3'
 import { name, version } from '../package.json'
 import vitePlugin from './hmr'
 import defaultTailwindConfig from './tailwind.config'

--- a/src/module.ts
+++ b/src/module.ts
@@ -234,8 +234,7 @@ export default defineNuxtModule<ModuleOptions>({
       const _viewerDevMiddleware = createServer({ tailwindConfigProvider: () => tailwindConfig, routerPrefix }).asMiddleware()
       const viewerDevMiddleware = eventHandler((event) => {
         if (event.req.url === withoutTrailingSlash(route)) {
-          event.res.writeHead(301, { Location: withTrailingSlash(event.req.url) })
-          return event.res.end()
+          return sendRedirect(event, withTrailingSlash(event.req.url), 301)
         }
         _viewerDevMiddleware(event.req, event.res)
       })

--- a/yarn.lock
+++ b/yarn.lock
@@ -4203,6 +4203,16 @@ h3@^0.7.12, h3@^0.7.21:
     radix3 "^0.1.2"
     ufo "^0.8.5"
 
+h3@^0.8.1:
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/h3/-/h3-0.8.1.tgz#e9992f09dd1abcf2c190d4cd068febf9bddafd41"
+  integrity sha512-HWTShxx4RKpse3f2h5KOWTEAIZLKq9SHWaVBZkOhBH+fH8uRGYY1iNO7VDwImFwARtR/Pg+bVI8feXX9NIdQRQ==
+  dependencies:
+    cookie-es "^0.5.0"
+    destr "^1.1.1"
+    radix3 "^0.2.1"
+    ufo "^0.8.5"
+
 handlebars@^4.7.7:
   version "4.7.7"
   resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.7.tgz#9ce33416aad02dbd6c8fafa8240d5d98004945a1"
@@ -7154,6 +7164,11 @@ radix3@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/radix3/-/radix3-0.1.2.tgz#5f7351af7fc5e4b1d9a1b14a7266b6a4a8cac0ba"
   integrity sha512-Mpfd/OuX0zoJ6ojLD/RTOHvJPg6e6PjINtmYzV87kIXc5iUtDz34i7gg4SV4XjqRJTmSiYO/g9i/mKWGf4z8wg==
+
+radix3@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/radix3/-/radix3-0.2.1.tgz#77e66a41c7ba5600a8bc137fd259ef661d314418"
+  integrity sha512-FnhArTl5Tq7dodiLeSPKrDUyCQuJqEncP8cKdyy399g8F/cz7GH6FmzA3Rkosu2IZMkpswFFwXfb2ERSiL06pg==
 
 randombytes@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
PR addresses a breaking change introduced in `h3@0.8`, which yields a warning on the latest Nuxt edge:

![image](https://user-images.githubusercontent.com/48835293/196004340-5c1da562-f1e2-4461-8d85-8607361d9fd4.png)
