### PR TITLE
docs: Mentioning the need of adding Tailwind directives

### DIFF
--- a/docs/content/1.getting-started/1.setup.md
+++ b/docs/content/1.getting-started/1.setup.md
@@ -68,6 +68,13 @@ You can configure the paths in the [module options](/getting-started/options).
 
 ::
 
+If you're going to create your own Tailwind CSS file, make sure to add the  `@tailwind` directives for each of Tailwind’s layers.
+```css
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+```
+
 Learn more about overwriting the Tailwind configuration in the [Tailwind Config](/tailwind/config) section.
 
 ## TypeScript (optional)


### PR DESCRIPTION
Mentioning the need of adding Tailwind directives to custom tailwind style files. If we create a custom file without adding that directives, it will not work and that part isn't mentioned or clear enough in the setup guide. And putting it there make it easy to copy/past during the setup :)