### PR TITLE
chore: remove `defineNuxtConfig` import

### DIFF
--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -1,4 +1,3 @@
-import { defineNuxtConfig } from 'nuxt'
 import tailwindModule from '../src/module'
 
 export default defineNuxtConfig({


### PR DESCRIPTION
`defineNuxtConfig` is now auto-imported.