### PR TITLE
fix: normalise undefined `nuxt.options.watch`

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -109,6 +109,7 @@ export default defineNuxtModule<ModuleOptions>({
 
     // Watch the Tailwind config file to restart the server
     if (nuxt.options.dev) {
+      nuxt.options.watch = nuxt.options.watch ?? []
       configPaths.forEach(path => nuxt.options.watch.push(path))
     }
 
@@ -143,7 +144,7 @@ export default defineNuxtModule<ModuleOptions>({
       getContents: () => `module.exports = ${JSON.stringify(resolvedConfig, null, 2)}`,
       write: true
     })
-    
+
     // Expose resolved tailwind config as an alias
     // https://tailwindcss.com/docs/configuration/#referencing-in-javascript
     if (moduleOptions.exposeConfig) {

--- a/src/module.ts
+++ b/src/module.ts
@@ -109,7 +109,7 @@ export default defineNuxtModule<ModuleOptions>({
 
     // Watch the Tailwind config file to restart the server
     if (nuxt.options.dev) {
-      nuxt.options.watch = nuxt.options.watch ?? []
+      nuxt.options.watch = nuxt.options.watch || []
       configPaths.forEach(path => nuxt.options.watch.push(path))
     }
 


### PR DESCRIPTION
Fixes an error in Nuxt [3.0.0-rc.13-27781123.265db50](https://www.npmjs.com/package/nuxt3/v/3.0.0-rc.13-27781123.265db50) and above caused by dropping schema normalisation for Nuxt 2 in https://github.com/nuxt/framework/pull/8487.

Thanks to @danielroe for the pointer!