### PR TITLE
🐛 FIX: Css option in  object format error.

### DIFF
--- a/declerations.d.ts
+++ b/declerations.d.ts
@@ -1,0 +1,17 @@
+import { ResolvePathOptions } from "@nuxt/kit";
+
+export type CSSOptionObjectFormat = {
+  src: string;
+  lang: string;
+};
+export type CSSOption = CSSOptionObjectFormat | string;
+declare interface ConfigSchema {
+  css: CSSOption;
+}
+
+declare module "@nuxt/kit" {
+  function resolvePath(
+    path: CSSOption,
+    opts?: ResolvePathOptions
+  ): Promise<string>;
+}

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,3 +1,4 @@
+import { CSSOption, CSSOptionObjectFormat } from '../declerations';
 import { existsSync } from 'fs'
 import { join, relative } from 'pathe'
 import defu, { defuArrayFn } from 'defu'
@@ -12,7 +13,7 @@ import {
   createResolver,
   resolvePath,
   addVitePlugin,
-  isNuxt3, findPath, requireModule
+  isNuxt3, findPath, requireModule, ResolvePathOptions
 } from '@nuxt/kit'
 import { Config } from 'tailwindcss'
 import { eventHandler, sendRedirect } from 'h3'
@@ -189,7 +190,8 @@ export default defineNuxtModule<ModuleOptions>({
       resolvedCss = createResolver(import.meta.url).resolve('runtime/empty.css')
     }
     nuxt.options.css = nuxt.options.css ?? []
-    const resolvedNuxtCss = await Promise.all(nuxt.options.css.map(p => resolvePath(p)))
+
+    const resolvedNuxtCss = await Promise.all(nuxt.options.css.map((p: CSSOption) => resolvePath((p as CSSOptionObjectFormat).src ?? p)))
 
     // Inject only if this file isn't listed already by user (e.g. user may put custom path both here and in css):
     if (!resolvedNuxtCss.includes(resolvedCss)) {


### PR DESCRIPTION
Pull request solving the issue of ["input.includes is not a function when adding a CSS with object format in nuxt.config.js CSS property"](https://github.com/nuxt-modules/tailwindcss/issues/554#issue-1428414801).