### PR TITLE
feat(exposeConfig): nested properties

### DIFF
--- a/docs/content/1.getting-started/2.options.md
+++ b/docs/content/1.getting-started/2.options.md
@@ -90,6 +90,29 @@ export default {
 
 Learn more about it in the [Referencing in the application](/tailwind/config#referencing-in-the-application) section.
 
+## `exposeLevel`
+
+- Default: `2`
+
+If you want to only import *really* specific parts of your tailwind config, you can enable imports for each property in the config:
+
+```ts [nuxt.config]
+export default {
+  tailwindcss: {
+    exposeConfig: true,
+    exposeLevel: 3
+  }
+}
+```
+
+This is only relevant when [`exposeConfig`](/getting-started/options#exposeconfig) is `true`. Using `exposeLevel` to be ≤ 0 will only expose root properties.
+
+::alert{type="warning"}
+
+It is unlikely for `exposeLevel` to ever be over 4 - the usual depth of a Tailwind config. A higher value is also likely to increase boot-time and disk space in dev.
+
+::
+
 ## `injectPosition`
 
 - Default: `'first'`

--- a/docs/content/1.getting-started/2.options.md
+++ b/docs/content/1.getting-started/2.options.md
@@ -113,6 +113,12 @@ It is unlikely for `exposeLevel` to ever be over 4 - the usual depth of a Tailwi
 
 ::
 
+::alert{type="info"}
+
+Named exports for properties below [root options](https://tailwindcss.com/docs/configuration#configuration-options) are prefixed with `_` (`_colors`, `_900`, `_2xl`) to ensure safe variable names. You can use default imports to provide any identifier or rename named imports using `as`. Properties with unsafe variable names (`spacing['1.5']`, `height['1/2']`, `keyframes.ping['75%, 100%']`) do not get exported individually.
+
+::
+
 ## `injectPosition`
 
 - Default: `'first'`

--- a/docs/content/2.tailwind/1.config.md
+++ b/docs/content/2.tailwind/1.config.md
@@ -240,8 +240,9 @@ import tailwindConfig from '#tailwind-config'
 import { theme } from '#tailwind-config'
 
 // Import within properties for further tree-shaking (based on exposeLevel)
-import { _neutral } from '#tailwind-config/theme/colors'
-import screens from '#tailwind-config/theme/screens'
+import screens from '#tailwind-config/theme/screens'  // default import
+import { _neutral } from '#tailwind-config/theme/colors'  // named (with _ prefix)
+import { _800 as slate800 } from '#tailwind-config/theme/colors/slate'  // alias
 ```
 
 ::alert{type="warning"}

--- a/docs/content/2.tailwind/1.config.md
+++ b/docs/content/2.tailwind/1.config.md
@@ -199,15 +199,15 @@ This merging strategy of with a function only applies to `plugins` and `content`
 
 ::
 
-### Whitelisting classes
+### Safelisting classes
 
-If you need to whitelist classes and avoid the content purge system, you need to specify the `safelist` option:
+If you need to safelist classes and avoid the content purge system, you need to specify the `safelist` option:
 
 ```js{}[tailwind.config.js]
 module.exports = {
-  // Whitelisting some classes to avoid content purge
+  // Safelisting some classes to avoid content purge
   safelist: [
-    'whitelisted',
+    'safelisted',
     {
       pattern: /bg-(red|green|blue)-(100|200|300)/,
     },
@@ -224,7 +224,8 @@ If you need resolved Tailwind config at runtime, you can enable the [exposeConfi
 ```js{}[nuxt.config]
 export default {
   tailwindcss: {
-    exposeConfig: true
+    exposeConfig: true,
+    // exposeLevel: 1,  // determines tree-shaking (optional)
   }
 }
 ```
@@ -237,6 +238,10 @@ import tailwindConfig from '#tailwind-config'
 
 // Import only part which is required to allow tree-shaking
 import { theme } from '#tailwind-config'
+
+// Import within properties for further tree-shaking (based on exposeLevel)
+import { _neutral } from '#tailwind-config/theme/colors'
+import screens from '#tailwind-config/theme/screens'
 ```
 
 ::alert{type="warning"}

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "postcss": "^8.4.18",
     "postcss-custom-properties": "^12.1.10",
     "postcss-nesting": "^10.2.0",
+    "scule": "^1.0.0",
     "tailwind-config-viewer": "^1.7.2",
     "tailwindcss": "^3.2.1",
     "ufo": "^0.8.6"

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "postcss": "^8.4.18",
     "postcss-custom-properties": "^12.1.10",
     "postcss-nesting": "^10.2.0",
-    "scule": "^1.0.0",
     "tailwind-config-viewer": "^1.7.2",
     "tailwindcss": "^3.2.1",
     "ufo": "^0.8.6"

--- a/src/module.ts
+++ b/src/module.ts
@@ -160,7 +160,6 @@ export default defineNuxtModule<ModuleOptions>({
             typeof value !== 'object' ||
             Array.isArray(value) ||
             Object.keys(value).find(k => !k.match(/^[0-9a-z]+$/i))
-            // || !Object.values(value).find((v) => typeof v === 'object')
           ) {
             addTemplate({
               filename: `tailwind.config/${path.concat(key).join('/')}.mjs`,

--- a/src/module.ts
+++ b/src/module.ts
@@ -154,10 +154,9 @@ export default defineNuxtModule<ModuleOptions>({
       const exposeMap = {}
       const populateMap = (obj, path = []) => {
         Object.entries(obj).forEach(([key, value]) => {
-          if (typeof value !== 'object' || Array.isArray(value)) {
+          if (typeof value !== 'object' || Array.isArray(value) || Object.keys(value).find(k => !k.match(/^[0-9a-z]+$/i))) {
             const exportName = camelCase(path.concat(key).join('-'))
-            exposeMap[exportName] =
-              typeof value === 'string' ? `"${value}"` : JSON.stringify(value)
+            exposeMap[exportName] = JSON.stringify(value)
           } else {
             // recurse through nested objects
             populateMap(value, path.concat(key))

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,7 +1,7 @@
 import { existsSync } from 'fs'
 import { join, relative } from 'pathe'
 import defu, { defuArrayFn } from 'defu'
-import { upperFirst, camelCase } from 'scule'
+import { pascalCase, camelCase } from 'scule'
 import chalk from 'chalk'
 import consola from 'consola'
 import {
@@ -165,7 +165,7 @@ export default defineNuxtModule<ModuleOptions>({
             // create export for parent object
             const exportName = camelCase(path.concat(key).join('-'))
             exposeMap[exportName] = `{ ${Object.keys(value)
-              .map(v => `${v}: ${exportName}${upperFirst(v)}`)
+              .map(v => `"${v}": ${exportName}${pascalCase(v)}`)
               .join(', ')} }`
           }
         })
@@ -180,7 +180,7 @@ export default defineNuxtModule<ModuleOptions>({
       })
       addTemplate({
         filename: 'tailwind.config.d.ts',
-        getContents: () => `type tailwindcssConfig = import("tailwindcss").Config\ndeclare const config: tailwindcssConfig\n${configOptions.map(o => `declare const ${o}: tailwindcssConfig["${o}"]`).join('\n')}\nexport { config as default, ${configOptions.join(', ')} }`,
+        getContents: () => `${Object.entries(exposeMap).map(([k, v]) => (`declare const ${k} = ${v}`)).join('\n')}\ndeclare const config = { ${configOptions.join(', ')} }\nexport { config as default, ${Object.keys(exposeMap).join(', ')} }`,
         write: true
       })
       nuxt.options.alias['#tailwind-config'] = template.dst

--- a/src/module.ts
+++ b/src/module.ts
@@ -153,7 +153,7 @@ export default defineNuxtModule<ModuleOptions>({
     // https://tailwindcss.com/docs/configuration/#referencing-in-javascript
     if (moduleOptions.exposeConfig) {
       const exposeMap = {}
-      const populateMap = (obj, path = [], level = 0, maxLevel = moduleOptions.exposeLevel) => {
+      const populateMap = (obj, path = [], level = 1, maxLevel = moduleOptions.exposeLevel) => {
         Object.entries(obj).forEach(([key, value]) => {
           if (
             level >= maxLevel ||

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -13,6 +13,7 @@ describe('tailwindcss module', async () => {
 
   await setupNuxtTailwind({
     exposeConfig: true,
+    exportLevel: 1,
     cssPath: r('tailwind.css')
   })
 
@@ -53,4 +54,11 @@ describe('tailwindcss module', async () => {
   //   expect(logger.info).toHaveBeenNthCalledWith(2, `Merging Tailwind config from ~/${relative(rootDir, nuxt.options.tailwindcss.configPath)}`)
   // })
   //
+
+  test('expose config', () => {
+    const nuxt = useTestContext().nuxt
+    const vfsKey = Object.keys(nuxt.vfs).find(k => k.includes('tailwind.config/theme/animation.'))
+    // check default tailwind default animation exists
+    expect(nuxt.vfs[vfsKey]).contains('"pulse": "pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite"')
+  })
 })

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -13,7 +13,7 @@ describe('tailwindcss module', async () => {
 
   await setupNuxtTailwind({
     exposeConfig: true,
-    exportLevel: 1,
+    exposeLevel: 2,
     cssPath: r('tailwind.css')
   })
 


### PR DESCRIPTION
While working on #582, I've also looked into how to create exports for nested properties in the large tailwind configuration, and these properties can be accessed using exports in camelCase. There have been use-cases (for me at least) where I need a small part of the configuration, such as `theme.screens` or `theme.colors.neutral` instead of all of `theme` (which is quite big), so I can just do

```ts
import { themeScreens, themeColorsNeutral } from '#tailwind-config'
```

and that should do it!

I believe this isn't a major requirement right now, and may need feedback as well (hence I'm also putting this as a draft PR).

Edit: see changes at this point through - https://github.com/nuxt-modules/tailwindcss/compare/main...ineshbose:nuxt-tailwindcss-module:ba8bf7e2f3e1d907e0ab7b1a29a03dfd6d0bcde7