### PR TITLE
chore(types): extending config type interface

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -43,10 +43,14 @@ export interface ModuleHooks {
 
 type Arrayable<T> = T | T[]
 
+interface ExtendTailwindConfig {
+  content: Config['content'] | ((contentDefaults: string[]) => Config['content']);
+}
+
 export interface ModuleOptions {
   configPath: Arrayable<string>;
   cssPath: string | false;
-  config: Config;
+  config: Omit<Config, keyof ExtendTailwindConfig> & ExtendTailwindConfig;
   viewer: boolean;
   exposeConfig: boolean;
   exposeLevel: number;


### PR DESCRIPTION
Follows #592 that fixed support for overriding default config (such as `content`) using `defu`, but lacked typed configuration - this implementation would help in future customisations too.