### PR TITLE
feat(exposeConfig): maximize nested exports

### DIFF
--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -57,8 +57,15 @@ describe('tailwindcss module', async () => {
 
   test('expose config', () => {
     const nuxt = useTestContext().nuxt
-    const vfsKey = Object.keys(nuxt.vfs).find(k => k.includes('tailwind.config/theme/animation.'))
+    const vfsKey = Object.keys(nuxt.vfs).find(k => k.includes('tailwind.config/theme/flexBasis.'))
     // check default tailwind default animation exists
-    expect(nuxt.vfs[vfsKey]).contains('"pulse": "pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite"')
+    expect(nuxt.vfs[vfsKey]).contains('"full": _full, "0.5": "0.125rem"')
+    expect(nuxt.vfs[vfsKey]).contains('export { config as default')
+  })
+
+  test('expose config variable', () => {
+    const nuxt = useTestContext().nuxt
+    const vfsKey = Object.keys(nuxt.vfs).find(k => k.includes('tailwind.config/theme/animation.'))
+    expect(nuxt.vfs[vfsKey]).contains('const _pulse = "pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite"')
   })
 })


### PR DESCRIPTION
This PR aims to squeeze out as many exports possible from the nested exports feature introduced in #583.

Behaviour before PR with default `exposeLevel: 2` for file `#tailwind-config/theme/flexBasis` (when `maxLevel` is hit and it is a terminating file):

```js
export default {
  // all properties in one object
  "96": "24rem",
  "auto": "auto",
  "px": "1px",
  "0.5": "0.125rem",
  "1.5": "0.375rem",
  "2.5": "0.625rem",
  "3.5": "0.875rem",
  "1/2": "50%",
}
```

Behaviour after PR:
```js
// ...all possible exports
const _96 = "24rem"
const _auto = "auto"
const _px = "1px"
const _full = "100%"

// same variables, along with unsafe vars
const config = { "96": _96, "auto": _auto, "px": _px, "full": _full, "0.5": "0.125rem", "1.5": "0.375rem", "2.5": "0.625rem", "3.5": "0.875rem", "1/2": "50%",  }

export { config as default, _0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _14, _16, _20, _24, _28, _32, _36, _40, _44, _48, _52, _56, _60, _64, _72, _80, _96, _auto, _px, _full }
```

(This will be the last PR for this feature - for a while at least - I promise 😉)