### PR TITLE
chore: add `utils` to default content path

### DIFF
--- a/docs/content/2.tailwind/1.config.md
+++ b/docs/content/2.tailwind/1.config.md
@@ -14,6 +14,7 @@ This module comes with a default Tailwind configuration file to provide the best
     `${srcDir}/pages/**/*.vue`,
     `${srcDir}/composables/**/*.{js,ts}`,
     `${srcDir}/plugins/**/*.{js,ts}`,
+    `${srcDir}/utils/**/*.{js,ts}`,
     `${srcDir}/App.{js,ts,vue}`,
     `${srcDir}/app.{js,ts,vue}`,
     `${srcDir}/Error.{js,ts,vue}`,

--- a/src/module.ts
+++ b/src/module.ts
@@ -31,6 +31,7 @@ const layerPaths = (srcDir: string) => ([
   `${srcDir}/pages/**/*.vue`,
   `${srcDir}/composables/**/*.{js,ts}`,
   `${srcDir}/plugins/**/*.{js,ts}`,
+  `${srcDir}/utils/**/*.{js,ts}`,
   `${srcDir}/App.{js,ts,vue}`,
   `${srcDir}/app.{js,ts,vue}`,
   `${srcDir}/Error.{js,ts,vue}`,


### PR DESCRIPTION
As `utils` are also auto-imported, it should be added to the default `content` path for the TailwindCSS module.