### PR TITLE
fix: add types to package.json exports map

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "exports": {
     ".": {
+      "types": "./dist/types.d.ts",
       "require": "./dist/module.cjs",
       "import": "./dist/module.mjs"
     }


### PR DESCRIPTION
when using ts with `"module": "nodenext" / "bundler"`, the `types` field is expected on `exports` in `package.json`.