### PR TITLE
feat: add quiet mode

### DIFF
--- a/docs/content/1.getting-started/2.options.md
+++ b/docs/content/1.getting-started/2.options.md
@@ -13,6 +13,7 @@ export default {
     config: {},
     injectPosition: 'first',
     viewer: true,
+    quiet: nuxt.options.logLevel === 'silent'
   }
 }
 ```
@@ -188,6 +189,22 @@ To disable the viewer during development, set its value to `false`:
 export default {
   tailwindcss: {
     viewer: false
+  }
+}
+```
+
+## `quiet`
+
+- Default: `nuxt.options.logLevel === 'silent'`
+
+Let's you disable the logging of the tailwind viewer path and the default tailwind config if everything is ok. Error's will still show up if something is wrong.
+
+To disable logging set its value to `true`:
+
+```ts [nuxt.config]
+export default {
+  tailwindcss: {
+    quiet: true
   }
 }
 ```

--- a/src/module.ts
+++ b/src/module.ts
@@ -42,7 +42,8 @@ const defaults = (nuxt = useNuxt()): ModuleOptions => ({
   exposeConfig: false,
   exposeLevel: 2,
   injectPosition: 'first',
-  disableHmrHotfix: false
+  disableHmrHotfix: false,
+  quiet: nuxt.options.logLevel === 'silent'
 })
 
 export default defineNuxtModule<ModuleOptions>({
@@ -93,7 +94,7 @@ export default defineNuxtModule<ModuleOptions>({
     /** CSS file handling */
     const cssPath = typeof moduleOptions.cssPath === 'string' ? await resolvePath(moduleOptions.cssPath, { extensions: ['.css', '.sass', '.scss', '.less', '.styl'] }) : false
     const [resolvedCss, loggerInfo] = resolveCSSPath(cssPath, nuxt)
-    logger.info(loggerInfo)
+    if (!moduleOptions.quiet) { logger.info(loggerInfo) }
 
     nuxt.options.css = nuxt.options.css ?? []
     const resolvedNuxtCss = await Promise.all(nuxt.options.css.map((p: any) => resolvePath(p.src ?? p)))
@@ -154,7 +155,7 @@ export default defineNuxtModule<ModuleOptions>({
       // Add _tailwind config viewer endpoint
       // TODO: Fix `addServerHandler` on Nuxt 2 w/o Bridge
       if (moduleOptions.viewer) {
-        setupViewer(tailwindConfig, nuxt)
+        setupViewer(tailwindConfig, nuxt, moduleOptions.quiet)
 
         nuxt.hook('devtools:customTabs', (tabs) => {
           tabs.push({

--- a/src/types.ts
+++ b/src/types.ts
@@ -53,4 +53,10 @@ export interface ModuleOptions {
    * @default false
    */
   disableHmrHotfix: boolean;
+  /**
+   * Suppress logging to the console when everything is ok
+   *
+   * @default nuxt.options.logLevel === 'silent'
+   */
+  quiet: boolean;
 }

--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -4,7 +4,7 @@ import { addDevServerHandler, isNuxt2, isNuxt3, useLogger, useNuxt } from '@nuxt
 import { withTrailingSlash, withoutTrailingSlash, joinURL } from 'ufo'
 import type { TWConfig } from './types'
 
-export default async function (twConfig: Partial<TWConfig>, nuxt = useNuxt()) {
+export default async function (twConfig: Partial<TWConfig>, nuxt = useNuxt(), quiet = false) {
   const route = joinURL(nuxt.options.app?.baseURL, '/_tailwind')
   // @ts-ignore
   const createServer = await import('tailwind-config-viewer/server/index.js').then(r => r.default || r) as any
@@ -20,7 +20,9 @@ export default async function (twConfig: Partial<TWConfig>, nuxt = useNuxt()) {
   // @ts-ignore
   if (isNuxt2()) { nuxt.options.serverMiddleware.push({ route, handler: (req, res) => viewerDevMiddleware(new H3Event(req, res)) }) }
   nuxt.hook('listen', (_, listener) => {
-    const viewerUrl = `${withoutTrailingSlash(listener.url)}${route}`.replace(/\/+/g, '/')
-    useLogger('nuxt:tailwindcss').info(`Tailwind Viewer: ${underline(yellow(withTrailingSlash(viewerUrl)))}`)
+    const viewerUrl = `${withoutTrailingSlash(listener.url)}${route}`
+    if (!quiet) {
+      useLogger('nuxt:tailwindcss').info(`Tailwind Viewer: ${underline(yellow(withTrailingSlash(viewerUrl)))}`)
+    }
   })
 }


### PR DESCRIPTION
This adds the possibility of disabling both of following logs:
- Tailwind Viewer url
- Defined TailwindCSS config path 

This only happens if everything is ok. 
Errors will still be visible.

The default will respect [nuxt `logLevel` settings](https://nuxt.com/docs/api/nuxt-config#loglevel).

This is a follow up on https://github.com/nuxt-modules/tailwindcss/pull/702 as it got stale.