### PR TITLE
fix: allow nuxt.options.pages to be unset

### DIFF
--- a/src/resolvers.ts
+++ b/src/resolvers.ts
@@ -45,7 +45,7 @@ export const resolveContentPaths = (srcDir: string, nuxt = useNuxt()) => {
     })(),
 
     r(`${nuxt.options.dir.layouts}/**/*${sfcExtensions}`),
-    ...(nuxt.options.pages ? [r(`${nuxt.options.dir.pages}/**/*${sfcExtensions}`)] : []),
+    ...([true, undefined].includes(nuxt.options.pages) ? [r(`${nuxt.options.dir.pages}/**/*${sfcExtensions}`)] : []),
 
     r(`${nuxt.options.dir.plugins}/**/*${defaultExtensions}`),
     r(`${nuxt.options.dir.modules}/**/*${defaultExtensions}`),


### PR DESCRIPTION
Weirdly enough the default isn't always set. The default is actually equal to "is the pages directory not empty" but assuming undefined means true is fine in this case as its only used to add a glob.

I also noticed use of `nuxt.options.dir.modules` causes an error to be logged to console, but removing that would be a breaking change now.

```
[16:13:24]  ERROR  This module cannot be imported in the Vue part of your app. [importing nuxt/kit from modules/my-module.ts]
```
