### PR TITLE
fix!: exclude modules from content

### DIFF
--- a/src/resolvers.ts
+++ b/src/resolvers.ts
@@ -48,7 +48,6 @@ export const resolveContentPaths = (srcDir: string, nuxt = useNuxt()) => {
     ...(nuxt.options.pages ? [r(`${nuxt.options.dir.pages}/**/*${sfcExtensions}`)] : []),
 
     r(`${nuxt.options.dir.plugins}/**/*${defaultExtensions}`),
-    r(`${nuxt.options.dir.modules}/**/*${defaultExtensions}`),
     ...importDirs.map(d => `${d}/**/*${defaultExtensions}`),
 
     r(`{A,a}pp${sfcExtensions}`),


### PR DESCRIPTION
https://github.com/nuxt-modules/tailwindcss/pull/747#issue-1974519872

Discussion: this may be a breaking change from `6.9.0`, but not from `<=6.8.1`, but you can argue that this is equivalent to "undoing" the change because the functionality remains the same from 6.8.1 onwards.