### PR TITLE
fix: allow options.imports to not be set

### DIFF
--- a/src/resolvers.ts
+++ b/src/resolvers.ts
@@ -30,7 +30,7 @@ export const resolveContentPaths = (srcDir: string, nuxt = useNuxt()) => {
   const defaultExtensions = extensionFormat(['js', 'ts', 'mjs'])
   const sfcExtensions = extensionFormat(nuxt.options.extensions.map(e => e.replace(/^\.*/, '')))
 
-  const importDirs = [...(nuxt.options.imports.dirs || [])].map(r)
+  const importDirs = [...(nuxt.options.imports?.dirs || [])].map(r)
   const [composablesDir, utilsDir] = [resolve(srcDir, 'composables'), resolve(srcDir, 'utils')]
 
   if (!importDirs.includes(composablesDir)) importDirs.push(composablesDir)


### PR DESCRIPTION
In the latest version, building a Nuxt2 app fails because `options.imports` is not defined. This change allows imports to not be defined and instead falls back to the empty array.