### PR TITLE
fix: always include vue extension in SFC content paths

### DIFF
--- a/src/resolvers.ts
+++ b/src/resolvers.ts
@@ -28,7 +28,8 @@ export const resolveContentPaths = (srcDir: string, nuxt = useNuxt()) => {
   const extensionFormat = (s: string[]) => s.length > 1 ? `.{${s.join(',')}}` : `.${s.join('') || 'vue'}`
 
   const defaultExtensions = extensionFormat(['js', 'ts', 'mjs'])
-  const sfcExtensions = extensionFormat(nuxt.options.extensions.map(e => e.replace(/^\.*/, '')))
+  const extensions = Array.from(new Set(['vue', ...nuxt.options.extensions]))
+  const sfcExtensions = extensionFormat(Array.from(new Set(['vue', ...nuxt.options.extensions])).map(e => e.replace(/^\.*/, '')))
 
   const importDirs = [...(nuxt.options.imports?.dirs || [])].map(r)
   const [composablesDir, utilsDir] = [resolve(srcDir, 'composables'), resolve(srcDir, 'utils')]


### PR DESCRIPTION
In my Nuxt2 app, `nuxt.options.extensions` is `[ 'js', 'mjs' ]`. This causes `.vue` to be excluded from tailwind.

This fix ensures that vue is always added as an extension, but I'm not sure if it's the correct approach. Maybe the options returned by nuxt kit should include it or maybe there is something wrong with my nuxt config? This does slightly change the behavior in that it's no longer possible to exclude vue files from tailwind, but I don't think that's a popular use-case.