### PR TITLE
refactor: resolve assets content path

### DIFF
--- a/src/resolvers.ts
+++ b/src/resolvers.ts
@@ -22,7 +22,8 @@ export const resolveConfigPath = async (path: Arrayable<string>) => (
  * @param srcDir
  * @returns array of resolved content globs
  */
-export const resolveContentPaths = (srcDir: string) => ([
+export const resolveContentPaths = (srcDir: string, assetDir?: string) => ([
+  `${srcDir}/${assetDir}/**/*.{css}`,
   `${srcDir}/components/**/*.{vue,js,ts}`,
   `${srcDir}/layouts/**/*.vue`,
   `${srcDir}/pages/**/*.vue`,
@@ -51,7 +52,7 @@ export const resolveModulePaths = async (configPath: ModuleOptions['configPath']
         resolveContentPaths(layer?.config?.srcDir || layer.cwd)
       ])))
     ).reduce((prev, curr) => prev.map((p, i) => p.concat(curr[i]))) as any
-  : [await resolveConfigPath(configPath), resolveContentPaths(nuxt.options.srcDir)]
+  : [await resolveConfigPath(configPath), resolveContentPaths(nuxt.options.srcDir, nuxt.options.dir.assets || 'assets')]
 )
 
 /**


### PR DESCRIPTION
For states that are outside of the Nuxt scope, it is hard for TailwindCSS to scan/extract the classes, for example, `dark mode`

There is a [color-mode](https://color-mode.nuxtjs.org/) module for handling this issue in SSR. 
But not all states are about dark mode, It can be anything

https://stackblitz.com/github/sadeghbarati/nuxt-tailwindcss-content-darkmode?file=nuxt.config.ts