### PR TITLE
feat: add util to write tw classes inside strings

### DIFF
--- a/docs/app.config.ts
+++ b/docs/app.config.ts
@@ -1,4 +1,4 @@
-import { version as pkgVersion } from '../package.json';
+import { version as pkgVersion } from '../package.json'
 
 export default defineAppConfig({
   ui: {

--- a/docs/content/1.getting-started/2.options.md
+++ b/docs/content/1.getting-started/2.options.md
@@ -160,3 +160,26 @@ export default defineNuxtConfig({
   }
 })
 ```
+
+## `addTwUtil `
+
+- Default: `false`
+
+This options adds the utility function `tw` that will provide intellisense suggestions in Js/Ts strings if the [Tailwind CSS IntelliSense](https://marketplace.visualstudio.com/items?itemName=bradlc.vscode-tailwindcss) extension is installed. For this to work, you will have to add the following VSCode setting:
+
+```json [settings.json]
+{
+  "tailwindCSS.experimental.classRegex": ["tw`([^`]*)", "tw\\('([^'\\)]*)"],
+}
+```
+
+Once modified, the new utility function can be used as follows, providing intellisense suggestions when writing Tailwind classes:
+
+```vue [index.vue]
+<script setup lang="ts">
+const variantClasses = {
+  primary: tw`bg-red-400`,
+  secondary: tw('bg-green-400')
+}
+</script>
+```

--- a/docs/content/1.getting-started/2.options.md
+++ b/docs/content/1.getting-started/2.options.md
@@ -165,7 +165,7 @@ export default defineNuxtConfig({
 
 - Default: `false`
 
-This option adds the utility function `tw` that will provide IntelliSense suggestions in Js/Ts strings if the [Tailwind CSS IntelliSense](https://marketplace.visualstudio.com/items?itemName=bradlc.vscode-tailwindcss) extension is installed. For this to work, you will have to add the following VSCode setting:
+This option adds the utility function `tw` that will provide IntelliSense suggestions in JS/TS strings if the [Tailwind CSS IntelliSense](https://marketplace.visualstudio.com/items?itemName=bradlc.vscode-tailwindcss) extension is installed. For this to work, you will have to add the following VSCode setting:
 
 ```json [settings.json]
 {

--- a/docs/content/1.getting-started/2.options.md
+++ b/docs/content/1.getting-started/2.options.md
@@ -165,7 +165,7 @@ export default defineNuxtConfig({
 
 - Default: `false`
 
-This options adds the utility function `tw` that will provide intellisense suggestions in Js/Ts strings if the [Tailwind CSS IntelliSense](https://marketplace.visualstudio.com/items?itemName=bradlc.vscode-tailwindcss) extension is installed. For this to work, you will have to add the following VSCode setting:
+This option adds the utility function `tw` that will provide IntelliSense suggestions in Js/Ts strings if the [Tailwind CSS IntelliSense](https://marketplace.visualstudio.com/items?itemName=bradlc.vscode-tailwindcss) extension is installed. For this to work, you will have to add the following VSCode setting:
 
 ```json [settings.json]
 {
@@ -173,7 +173,7 @@ This options adds the utility function `tw` that will provide intellisense sugge
 }
 ```
 
-Once modified, the new utility function can be used as follows, providing intellisense suggestions when writing Tailwind classes:
+Once added, the new utility function can be used as follows, providing IntelliSense suggestions when writing Tailwind classes:
 
 ```vue [index.vue]
 <script setup lang="ts">

--- a/src/module.ts
+++ b/src/module.ts
@@ -137,7 +137,6 @@ export default defineNuxtModule<ModuleOptions>({
       await installModule('@nuxt/postcss8')
     }
 
-
     if(moduleOptions.addTwUtil) {
       addImportsDir(resolve('./runtime/utils'));
     }

--- a/src/module.ts
+++ b/src/module.ts
@@ -10,7 +10,9 @@ import {
   resolvePath,
   addVitePlugin,
   useNuxt,
-  addTemplate
+  addTemplate,
+  addImportsDir,
+  createResolver
 } from '@nuxt/kit'
 
 // @ts-expect-error
@@ -45,12 +47,14 @@ const defaults = (nuxt = useNuxt()): ModuleOptions => ({
   exposeConfig: false,
   exposeLevel: 2,
   injectPosition: 'first',
-  disableHmrHotfix: false
+  disableHmrHotfix: false,
+  addTwUtil: false,
 })
 
 export default defineNuxtModule<ModuleOptions>({
   meta: { name, version, configKey, compatibility }, defaults,
   async setup (moduleOptions, nuxt) {
+    const { resolve } = createResolver(import.meta.url);
     const [configPaths, contentPaths] = await resolveModulePaths(moduleOptions.configPath, nuxt)
 
     const tailwindConfig = await Promise.all((
@@ -131,6 +135,11 @@ export default defineNuxtModule<ModuleOptions>({
     // install postcss8 module on nuxt < 2.16
     if (parseFloat(getNuxtVersion()) < 2.16) {
       await installModule('@nuxt/postcss8')
+    }
+
+
+    if(moduleOptions.addTwUtil) {
+      addImportsDir(resolve('./runtime/utils'));
     }
 
     // enabled only in development

--- a/src/module.ts
+++ b/src/module.ts
@@ -137,7 +137,7 @@ export default defineNuxtModule<ModuleOptions>({
       await installModule('@nuxt/postcss8')
     }
 
-    if(moduleOptions.addTwUtil) {
+    if (moduleOptions.addTwUtil) {
       addImportsDir(resolve('./runtime/utils'));
     }
 

--- a/src/runtime/utils/tw.ts
+++ b/src/runtime/utils/tw.ts
@@ -1,0 +1,3 @@
+export const tw = function (tailwindClasses: TemplateStringsArray | string) {
+  return tailwindClasses
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -90,4 +90,10 @@ export interface ModuleOptions {
    * @default false
    */
   disableHmrHotfix: boolean;
+  /**
+   * Add util to write Tailwind CSS classes inside strings with `` tw`{classes}` ``
+   * 
+   * @default false
+   */
+  addTwUtil: boolean;
 }


### PR DESCRIPTION
> There are documentation changes missing in this PR. I want to know your opinion on this first before continuing the development.

# Description

More often than not, there are times when you may want to write Tailwind CSS classes within TypeScript strings. For example:

```vue
<script setup lang="ts">
const variant = ref('primary');

const variantClasses = {
  primary: "bg-red-400",
  secondary: "bg-green-400",
};
</script>

<template>
  <button :class="variantClasses[variant]">Click me</button>
</template>
```

When doing so, you lose intellisense in VSCode through [TailwindCSS extension](https://marketplace.visualstudio.com/items?itemName=bradlc.vscode-tailwindcss). To overcome this problem, the extension team created a setting to allow for [custom class name completion contexts](https://github.com/tailwindlabs/tailwindcss/issues/7553).

I thought it would be nice if this library helped the DX of TailwindCSS classes by providing a util function that when paired with the correct VSCode setting, it would automatically generate suggestions.

# Approach

We can provide the following auto-imported function under the flag `addTwUtil`:

```typescript
export const tw = function (tailwindClasses: TemplateStringsArray | string) {
  return tailwindClasses
}
```

We can also add in the documentation that users should add the following configuration in VSCode:

```json
  "tailwindCSS.experimental.classRegex": ["tw`(.*?)`", "tw\\('(.*?)'\\)"],
```

With these modifications, users of this module will now be able to write TailwindCSS classes like this:

```typescript
const variantClasses = {
  primary: tw`bg-red-400`,
  secondary: tw`bg-green-400`,
};
```

Here's a small video showcasing the use case:

https://github.com/nuxt-modules/tailwindcss/assets/7190600/8d50cf7a-7ee7-4b3a-b749-72a613e9999f

I feel like this could improve a lot the DX when using Tailwind CSS classes. I'm not sure if this is something you are willing to add to this module since it's very coupled to VSCode development and it requires modification of VSCode settings to work (that's why I set `addTwUtil` to be `false` by default).