### PR TITLE
refactor: move `injectPosition` to `cssPath`

### DIFF
--- a/docs/content/1.getting-started/2.configuration.md
+++ b/docs/content/1.getting-started/2.configuration.md
@@ -48,6 +48,37 @@ export default defineNuxtConfig({
 When set to `false`, note that HMR for tailwindcss will be broken (hard refresh needed).
 ::
 
+To adjust the position of the global CSS injection, affecting the CSS priority, you can provide configuration to `cssPath` through the second element of an array like so:
+
+```ts [nuxt.config.ts]
+export default defineNuxtConfig({
+  css: [
+    'assets/low-priorty.pcss',
+    'assets/high-priorty.pcss'
+  ],
+  tailwindcss: {
+    cssPath: ['~/assets/css/tailwind.css', { injectionPosition: 'last' }],
+    // cssPath: [
+    //   false,   // can also use when cssPath: false
+    //   {
+    //     injectPosition: { 
+    //         // 'low-priority' will have lower priority than Tailwind stylesheet, 
+    //         // while 'high-priorty' will override it
+    //         after: 'assets/low-priorty.pcss'
+    //     }
+    //     injectPosition: 'first'   // default, equal to nuxt.options.css.unshift(cssPath)
+    //     injectPosition: 'last'    // equal to nuxt.options.css.push(cssPath)
+    //     injectPosition: 1         // after 'low-priority.pcss'
+    //   }
+    // ]
+  }
+})
+```
+
+* Use `'first'` and `'last'` literals to make Tailwind CSS first or last respectively. First position has the lowest priority, last position overrides everything and hence has the highest priority.
+* Use `{ after: 'some/existing/file.css' } ` to explicitly specify the position.
+* You can use any integer to specify absolute position in the array. This approach is less stable, as it can be easy to forget to adjust it when changing CSS settings.
+
 ## `configPath`
 
 - Default: `'tailwind.config'`
@@ -87,37 +118,6 @@ export default defineNuxtConfig({
 ```
 
 Learn more about it in the [Referencing in the application](/tailwind/config#referencing-in-the-application) section.
-
-## `injectPosition`
-
-- Default: `'first'`
-
-This option lets you adjust the position of the [global CSS](https://nuxt.com/docs/api/configuration/nuxt-config#css) injection, which affects the CSS priority. You can use multiple formats to define the position:
-
-* Use `'first'` and `'last'` literals to make Tailwind CSS first or last respectively. First position has the lowest priority, last position overrides everything and hence has the highest priority.
-* Use `{ after: 'some/existing/file.css' } ` to explicitly specify the position.
-* You can use any integer to specify absolute position in the array. This approach is less stable, as it can be easy to forget to adjust it when changing CSS settings.
-
-```ts [nuxt.config.ts]
-export default defineNuxtConfig({
-  css: [
-    'assets/low-priorty.pcss',
-    'assets/high-priorty.pcss'
-  ],
-  tailwindcss: {
-    injectPosition: { 
-        // 'low-priority' will have lower priority than Tailwind stylesheet, 
-        // while 'high-priorty' will override it
-        after: 'assets/low-priorty.pcss'
-    }
-    // injectPosition: 'first'   // equal to nuxt.options.css.unshift(cssPath)
-    // injectPosition: 'last'    // equal to nuxt.options.css.push(cssPath)
-    // injectPosition: 1         // after 'low-priority.pcss'
-  }
-})
-```
-
-Learn more about overwriting Tailwind config [here](/tailwind/config#overwriting-the-configuration).
 
 ## `config`
 

--- a/package.json
+++ b/package.json
@@ -24,11 +24,11 @@
   "scripts": {
     "dev": "nuxi dev playground",
     "play": "pnpm dev",
-    "prepare": "nuxt-module-build prepare",
+    "prepare": "nuxt-module-build prepare && nuxt-module-build build --stub",
     "dev:build": "nuxi build playground",
     "dev:generate": "nuxi generate playground",
     "dev:nuxt2": "nuxi dev nuxt2-playground",
-    "dev:prepare": "pnpm prepare && nuxt-module-build build --stub && nuxi prepare playground && nuxi prepare docs",
+    "dev:prepare": "pnpm prepare",
     "build": "nuxt-module-build build",
     "prepack": "pnpm build",
     "release": "pnpm lint && pnpm test && pnpm prepack && pnpm changelogen --release --push && pnpm publish",

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -8,7 +8,7 @@ export default defineNuxtConfig({
   tailwindcss: {
     // viewer: false,
     exposeConfig: true,
-    injectPosition: 'last',
+    cssPath: ['~/assets/css/tailwind.css', { injectPosition: 'last' }],
     editorSupport: true
   },
   content: {

--- a/src/module.ts
+++ b/src/module.ts
@@ -107,10 +107,10 @@ export default defineNuxtModule<ModuleOptions>({
     logger.info(loggerInfo)
 
     nuxt.options.css = nuxt.options.css ?? []
-    const resolvedNuxtCss = await Promise.all(nuxt.options.css.map((p: any) => resolvePath(p.src ?? p)))
+    const resolvedNuxtCss = resolvedCss && await Promise.all(nuxt.options.css.map((p: any) => resolvePath(p.src ?? p))) || []
 
     // Inject only if this file isn't listed already by user (e.g. user may put custom path both here and in css):
-    if (!resolvedNuxtCss.includes(resolvedCss)) {
+    if (resolvedCss && !resolvedNuxtCss.includes(resolvedCss)) {
       let injectPosition: number
       try {
         injectPosition = resolveInjectPosition(nuxt.options.css, cssPathConfig?.injectPosition || moduleOptions.injectPosition)

--- a/src/module.ts
+++ b/src/module.ts
@@ -100,8 +100,10 @@ export default defineNuxtModule<ModuleOptions>({
 
 
     /** CSS file handling */
-    const cssPath = typeof moduleOptions.cssPath === 'string' ? await resolvePath(moduleOptions.cssPath, { extensions: ['.css', '.sass', '.scss', '.less', '.styl'] }) : false
-    const [resolvedCss, loggerInfo] = await resolveCSSPath(cssPath, nuxt)
+    const [cssPath, cssPathConfig] = Array.isArray(moduleOptions.cssPath) ? moduleOptions.cssPath : [moduleOptions.cssPath]
+    const [resolvedCss, loggerInfo] = await resolveCSSPath(
+      typeof cssPath === 'string' ? await resolvePath(cssPath, { extensions: ['.css', '.sass', '.scss', '.less', '.styl'] }) : false, nuxt
+    )
     logger.info(loggerInfo)
 
     nuxt.options.css = nuxt.options.css ?? []
@@ -111,7 +113,7 @@ export default defineNuxtModule<ModuleOptions>({
     if (!resolvedNuxtCss.includes(resolvedCss)) {
       let injectPosition: number
       try {
-        injectPosition = resolveInjectPosition(nuxt.options.css, moduleOptions.injectPosition)
+        injectPosition = resolveInjectPosition(nuxt.options.css, cssPathConfig?.injectPosition || moduleOptions.injectPosition)
       } catch (e: any) {
         throw new Error('failed to resolve Tailwind CSS injection position: ' + e.message)
       }

--- a/src/resolvers.ts
+++ b/src/resolvers.ts
@@ -84,7 +84,7 @@ export const resolveModulePaths = async (configPath: ModuleOptions['configPath']
  * @param nuxt
  * @returns [resolvedCss, loggerMessage]
  */
-export async function resolveCSSPath (cssPath: ModuleOptions['cssPath'], nuxt = useNuxt()): Promise<[string, string]> {
+export async function resolveCSSPath (cssPath: Exclude<ModuleOptions['cssPath'], Array<any>>, nuxt = useNuxt()): Promise<[string, string]> {
   if (typeof cssPath === 'string') {
     return existsSync(cssPath)
       ? [cssPath, `Using Tailwind CSS from ~/${relative(nuxt.options.srcDir, cssPath)}`]
@@ -134,7 +134,7 @@ export const resolveEditorSupportConfig = (config: ModuleOptions['editorSupport'
  *
  * @returns index in the css array
  */
-export function resolveInjectPosition (css: string[], position: InjectPosition) {
+export function resolveInjectPosition (css: string[], position: InjectPosition = 'first') {
   if (typeof (position) === 'number') {
     return ~~Math.min(position, css.length + 1)
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -92,7 +92,7 @@ export interface ModuleOptions {
    *
    * @default '~/assets/css/tailwind.css'
    */
-  cssPath: string | false;
+  cssPath: string | false | [string | false, { injectPosition: InjectPosition }];
   /**
    * Configuration for Tailwind CSS
    *
@@ -122,6 +122,7 @@ export interface ModuleOptions {
    * The position of CSS injection affecting CSS priority
    *
    * @default 'first'
+   * @deprecated use cssPath as [string | false, { injectPosition: InjectPosition }]
    */
   injectPosition: InjectPosition;
   /**

--- a/src/vite-hmr.ts
+++ b/src/vite-hmr.ts
@@ -3,7 +3,7 @@ import type { Plugin as VitePlugin } from 'vite'
 import type { TWConfig } from './types'
 import micromatch from 'micromatch'
 
-export default function (tailwindConfig: Partial<TWConfig> = {}, rootDir: string, cssPath: string): VitePlugin {
+export default function (tailwindConfig: Partial<TWConfig> = {}, rootDir: string, cssPath: string | false): VitePlugin {
   const resolvedContent = ((Array.isArray(tailwindConfig.content) ? tailwindConfig.content : tailwindConfig.content?.files || []).filter(f => typeof f === 'string') as Array<string>).map(f => !isAbsolute(f) ? resolve(rootDir, f) : f)
 
   return {
@@ -13,7 +13,7 @@ export default function (tailwindConfig: Partial<TWConfig> = {}, rootDir: string
         return
       }
 
-      const extraModules = ctx.server.moduleGraph.getModulesByFile(cssPath) || new Set()
+      const extraModules = cssPath && ctx.server.moduleGraph.getModulesByFile(cssPath) || new Set()
       const timestamp = +Date.now()
 
       for (const mod of extraModules) {


### PR DESCRIPTION
This should also make `injectPosition` more clear to be related to `cssPath` and not add to root-config.

Last config change I promise!