### PR TITLE
docs: add export default to default config example

### DIFF
--- a/docs/content/2.tailwind/1.config.md
+++ b/docs/content/2.tailwind/1.config.md
@@ -6,7 +6,7 @@ description: This module comes with a default Tailwind configuration file to pro
 ## Default configuration
 
 ```js [tailwind.config.js]
-{
+export default {
   theme: {},
   plugins: [],
   content: [


### PR DESCRIPTION
I noticed the missing `export default` in the JS file when copying it into my project.