### PR TITLE
refactor: move `colorette` to `consola/utils`

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "autoprefixer": "^10.4.17",
     "chokidar": "^3.5.3",
     "clear-module": "^4.1.2",
-    "colorette": "^2.0.20",
     "consola": "^3.2.3",
     "defu": "^6.1.4",
     "h3": "^1.10.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,9 +23,6 @@ importers:
       clear-module:
         specifier: ^4.1.2
         version: 4.1.2
-      colorette:
-        specifier: ^2.0.20
-        version: 2.0.20
       consola:
         specifier: ^3.2.3
         version: 3.2.3

--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -1,4 +1,4 @@
-import { underline, yellow } from 'colorette'
+import { colors } from 'consola/utils'
 import { eventHandler, sendRedirect, H3Event } from 'h3'
 import { addDevServerHandler, isNuxt2, isNuxt3, useNuxt } from '@nuxt/kit'
 import { withTrailingSlash, withoutTrailingSlash, joinURL, cleanDoubleSlashes } from 'ufo'
@@ -43,7 +43,7 @@ export const setupViewer = async (twConfig: Partial<TWConfig>, config: ViewerCon
 
   nuxt.hook('listen', (_, listener) => {
     const viewerUrl = cleanDoubleSlashes(joinURL(listener.url, config.endpoint))
-    logger.info(`Tailwind Viewer: ${underline(yellow(withTrailingSlash(viewerUrl)))}`)
+    logger.info(`Tailwind Viewer: ${colors.underline(colors.yellow(withTrailingSlash(viewerUrl)))}`)
   })
 }
 
@@ -57,6 +57,6 @@ export const exportViewer = async (pathToConfig: string, config: ViewerConfig, n
 
     const dir = joinURL(nitro.options.output.publicDir, config.endpoint)
     cli(dir, pathToConfig)
-    logger.success(`Exported viewer to ${yellow(relative(nuxt.options.srcDir, dir))}`)
+    logger.success(`Exported viewer to ${colors.yellow(relative(nuxt.options.srcDir, dir))}`)
   })
 }


### PR DESCRIPTION

https://github.com/unjs/consola/tree/v3.2.3?tab=readme-ov-file#console-utils
https://github.com/unjs/consola/blob/v3.2.3/src/utils/color.ts