### PR TITLE
docs: update Nuxt Tailwind configuration docs

### DIFF
--- a/docs/content/1.getting-started/2.configuration.md
+++ b/docs/content/1.getting-started/2.configuration.md
@@ -7,12 +7,12 @@ description: Configure Nuxt Tailwind with the `tailwindcss` property.
 export default {
   // Defaults options
   tailwindcss: {
-    cssPath: '~/assets/css/tailwind.css',
+    cssPath: ['~/assets/css/tailwind.css', { injectPosition: "first" }],
     configPath: 'tailwind.config',
-    exposeConfig: false,
-    exposeLevel: 2,
+    exposeConfig: {
+      level: 2
+    },
     config: {},
-    injectPosition: 'first',
     viewer: true,
   }
 }


### PR DESCRIPTION
This pull request is intended to update the `configuration` page in the Nuxt Tailwind documentation with the latest configurations to get rid of the deprecation warnings shown below: 

![nuxt-tailwind](https://github.com/nuxt-modules/tailwindcss/assets/106826371/f774d893-5ccd-47c0-865a-2b494e819d5d)
