### PR TITLE
docs: use new `nuxi module add` command in installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,14 +31,7 @@
 1. Add `@nuxtjs/tailwindcss` dependency to your project
 
 ```bash
-# Using pnpm
-pnpm add --save-dev @nuxtjs/tailwindcss
-
-# Using yarn
-yarn add --dev @nuxtjs/tailwindcss
-
-# Using npm
-npm install --save-dev @nuxtjs/tailwindcss
+npx nuxi@latest module add tailwindcss
 ```
 
 *You can test latest additions on [Nightly Releases](https://tailwindcss.nuxtjs.org/getting-started/installation#nightly-releases)!*

--- a/README.md
+++ b/README.md
@@ -28,15 +28,26 @@
 
 ## Quick Setup
 
-1. Add `@nuxtjs/tailwindcss` dependency to your project
+Add `@nuxtjs/tailwindcss` using the [Nuxt CLI](https://github.com/nuxt/cli) to your project
 
 ```bash
 npx nuxi@latest module add tailwindcss
 ```
 
-*You can test latest additions on [Nightly Releases](https://tailwindcss.nuxtjs.org/getting-started/installation#nightly-releases)!*
+or add `@nuxtjs/tailwindcss` using your dependency manager
 
-2. Add `@nuxtjs/tailwindcss` to the `modules` section of `nuxt.config.{ts,js}`
+```bash
+# Using pnpm
+pnpm add --save-dev @nuxtjs/tailwindcss
+
+# Using yarn
+yarn add --dev @nuxtjs/tailwindcss
+
+# Using npm
+npm install --save-dev @nuxtjs/tailwindcss
+```
+
+and then to the `modules` section of `nuxt.config.{ts,js}`
 
 ```ts
 export default defineNuxtConfig({
@@ -47,6 +58,8 @@ export default defineNuxtConfig({
 ```
 
 That's it! You can now use Tailwind classes in your Nuxt app ✨
+
+*You can test latest additions on [Nightly Releases](https://tailwindcss.nuxtjs.org/getting-started/installation#nightly-releases)!*
 
 [📖 &nbsp;Read more](https://tailwindcss.nuxtjs.org/getting-started/)
 

--- a/docs/content/1.getting-started/1.installation.md
+++ b/docs/content/1.getting-started/1.installation.md
@@ -6,11 +6,28 @@ description: Using Tailwind CSS in your Nuxt project is only one command away.
 ## Installation
 
 1. Install `@nuxtjs/tailwindcss` dependency to your project:
-```bash
+
+::code-group
+
+```bash [nuxi]
 npx nuxi@latest module add tailwindcss
 ```
 
-2. Add it to your `modules` section in your `nuxt.config`:
+```bash [yarn]
+yarn add -D @nuxtjs/tailwindcss
+```
+
+```bash [npm]
+npm install -D @nuxtjs/tailwindcss
+```
+
+```sh [pnpm]
+pnpm i -D @nuxtjs/tailwindcss
+```
+
+::
+
+2. If not already done, add it to your `modules` section in your `nuxt.config`:
 
 ::code-group
 ```ts [Nuxt 3]

--- a/docs/content/1.getting-started/1.installation.md
+++ b/docs/content/1.getting-started/1.installation.md
@@ -6,22 +6,9 @@ description: Using Tailwind CSS in your Nuxt project is only one command away.
 ## Installation
 
 1. Install `@nuxtjs/tailwindcss` dependency to your project:
-
-::code-group
-
-```bash [yarn]
-yarn add -D @nuxtjs/tailwindcss
+```bash
+npx nuxi@latest module add tailwindcss
 ```
-
-```bash [npm]
-npm install -D @nuxtjs/tailwindcss
-```
-
-```sh [pnpm]
-pnpm i -D @nuxtjs/tailwindcss
-```
-
-::
 
 2. Add it to your `modules` section in your `nuxt.config`:
 


### PR DESCRIPTION

This updates the documentation to use the [`nuxi module add` command](https://github.com/nuxt/cli/pull/197) which should simplify docs a bit and also improve user experience as there's no need to add to `nuxt.config` manually.

It's documented [here](https://nuxt.com/docs/api/commands/module#nuxi-module-add).

I may have missed a few spots in the documentation as I'm doing this across the modules ecosystem assisted by the power of regular expressions ✨, so I'd appreciate a review 🙏
