### PR TITLE
 fix: #883 Tab view src leading baseURL

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -1,5 +1,5 @@
 import { join } from 'pathe'
-import { withoutTrailingSlash, withTrailingSlash } from 'ufo'
+import { joinURL } from 'ufo'
 import {
   defineNuxtModule,
   installModule,
@@ -142,7 +142,7 @@ export default defineNuxtModule<ModuleOptions>({
               category: 'modules',
               view: {
                 type: 'iframe',
-                src: withTrailingSlash((nuxt.options.app?.baseURL === '/' ? '' : withoutTrailingSlash(nuxt.options.app.baseURL)) + viewerConfig.endpoint)
+                src: joinURL(nuxt.options.app?.baseURL, viewerConfig.endpoint),
               },
             })
           })

--- a/src/module.ts
+++ b/src/module.ts
@@ -142,7 +142,7 @@ export default defineNuxtModule<ModuleOptions>({
               category: 'modules',
               view: {
                 type: 'iframe',
-                src: withTrailingSlash(viewerConfig.endpoint),
+                src: withTrailingSlash(nuxt.options.app?.baseURL + viewerConfig.endpoint),
               },
             })
           })

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,5 +1,5 @@
 import { join } from 'pathe'
-import { withTrailingSlash } from 'ufo'
+import { withoutTrailingSlash, withTrailingSlash } from 'ufo'
 import {
   defineNuxtModule,
   installModule,
@@ -142,7 +142,7 @@ export default defineNuxtModule<ModuleOptions>({
               category: 'modules',
               view: {
                 type: 'iframe',
-                src: withTrailingSlash(nuxt.options.app?.baseURL + viewerConfig.endpoint),
+                src: withTrailingSlash((nuxt.options.app?.baseURL === '/' ? '' : withoutTrailingSlash(nuxt.options.app.baseURL)) + viewerConfig.endpoint)
               },
             })
           })


### PR DESCRIPTION
Fixed issue #883: `Cannot find any path matching /_tailwind/`, when using `baseUrl`: `/dev/`.
Additionally added conditional `baseURL` output, where if it matches `/` it prefixes empty string `''`, making final Tab view src always `/dev/_tailwind/` (depending on `nuxt.config.ts`) or `/_tailwind/`.

### 🔗 Linked issue
Issue #883

### ❓ Type of change
- [ x] 🐞 Bug fix (a non-breaking change that fixes an issue)

### 📚 Description

```
 Fixed issue #883: Cannot find any path matching /_tailwind/, when using baseUrl: '/dev/'.
 ```
 
 This change is required to fix _Tailwind Config Viewer_ embedded url by appending missing [`baseUrl`](https://nuxt.com/docs/api/nuxt-config#baseurl) setting (if set).