### PR TITLE
docs: mention `tailwindcss-cli` if `tailwindcss init` fails

### DIFF
--- a/docs/content/1.getting-started/1.installation.md
+++ b/docs/content/1.getting-started/1.installation.md
@@ -101,15 +101,15 @@ You can create the `tailwind.config.js` file by running the following command, a
 ::code-group
 
 ```bash [npm]
-npx tailwindcss@latest init
+npx tailwindcss init
 ```
 
 ```bash [yarn]
-yarn tailwindcss@latest init
+yarn tailwindcss init
 ```
 
 ```sh [pnpm]
-pnpm dlx tailwindcss@latest init
+pnpm dlx tailwindcss init
 ```
 
 ::

--- a/docs/content/1.getting-started/1.installation.md
+++ b/docs/content/1.getting-started/1.installation.md
@@ -101,15 +101,15 @@ You can create the `tailwind.config.js` file by running the following command, a
 ::code-group
 
 ```bash [npm]
-npx tailwindcss init
+npx tailwindcss-cli@latest init
 ```
 
 ```bash [yarn]
-yarn tailwindcss init
+yarn tailwindcss-cli@latest init
 ```
 
 ```sh [pnpm]
-pnpm dlx tailwindcss init
+pnpm dlx tailwindcss-cli@latest init
 ```
 
 ::

--- a/docs/content/1.getting-started/1.installation.md
+++ b/docs/content/1.getting-started/1.installation.md
@@ -101,17 +101,21 @@ You can create the `tailwind.config.js` file by running the following command, a
 ::code-group
 
 ```bash [npm]
-npx tailwindcss-cli@latest init
+npx tailwindcss@latest init
 ```
 
 ```bash [yarn]
-yarn tailwindcss-cli@latest init
+yarn tailwindcss@latest init
 ```
 
 ```sh [pnpm]
-pnpm dlx tailwindcss-cli@latest init
+pnpm dlx tailwindcss@latest init
 ```
 
+::
+
+::callout{color="amber" icon="i-ph-warning-duotone"}
+If the above fails, you can try `npx tailwindcss-cli init`.
 ::
 
 If you're going to create your own CSS file for Tailwind CSS, make sure to add the [`@tailwind`](https://tailwindcss.com/docs/functions-and-directives#tailwind) directives:


### PR DESCRIPTION
Updated the init commands because the other one doesn't work. Found this solution here: https://www.devgem.io/posts/why-npx-tailwindcss-init-fails-and-how-to-fix-it

### 🔗 Linked issue

Not that I could find.

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

I have updated the documentation for the init command. The current one online doesn't work, so I found a solution on https://www.devgem.io/posts/why-npx-tailwindcss-init-fails-and-how-to-fix-it

So I thought let's update this for everyone 👍

If my title is not correct, or if I need to change something, please let me know 😉
