### PR TITLE
fix: content resolution for [...path].vue pages

### DIFF
--- a/src/internal-context/load.ts
+++ b/src/internal-context/load.ts
@@ -81,7 +81,8 @@ const createInternalContext = async (moduleOptions: ModuleOptions, nuxt = useNux
       const pageFiles = pagesContentPath.tryUse()
 
       if (pageFiles && pageFiles.length) {
-        rootProjectFiles.push(...pageFiles)
+        // replace filenames like [...path].vue with ?...path?.vue because [ and ] are reserved in glob matching
+        rootProjectFiles.push(...pageFiles.map(p => p.replaceAll(/\[(\.+)([^.].*)\]/g, '?$1$2?')))
       }
       // @ts-expect-error pages can be an object
       else if (nuxtOptions.pages !== false && nuxtOptions.pages?.enabled !== false) {


### PR DESCRIPTION
### 🔗 Linked issue

#964 

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Tailwindcss does not seem to work with content like this `pages/to/[...path].vue`. This change will replace those paths with a content like this `pages/to/?...path?.vue`. The question mark means any character. I tried many ways (like escaping the brackets) but they didn't seem to work.

I didn't write unit tests as the unit test system wasn't clear. Maybe if someone can give me an idea how to do this, I can write the tests.
