### PR TITLE
fix: try resolving `tailwindcss` from module

### DIFF
--- a/src/resolvers.ts
+++ b/src/resolvers.ts
@@ -16,7 +16,7 @@ export async function resolveCSSPath(cssPath: Exclude<ModuleOptions['cssPath'], 
 
     return existsSync(_cssPath)
       ? [_cssPath, `Using Tailwind CSS from ~/${relative(nuxt.options.srcDir, _cssPath)}`]
-      : await tryResolveModule('tailwindcss/package.json')
+      : await tryResolveModule('tailwindcss/package.json', import.meta.url)
         .then(twLocation => twLocation ? [join(twLocation, '../tailwind.css'), 'Using default Tailwind CSS file'] : Promise.reject('Unable to resolve tailwindcss. Is it installed?'))
   }
   else {


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

noticed this issue when multiple versions of tailwindcss were present in a monorepo. It's probably safest to resolve tailwind from the module itself given that it's a dependency of it (and pinned to `~3.4`)