### PR TITLE
Apply fix from `6.14` (main) to `6.12.2` to bypass regression

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,8 @@
     "lint:fix": "pnpm lint --fix",
     "test": "vitest run",
     "test:watch": "vitest watch",
-    "test:types": "pnpm dev:prepare && tsc --noEmit && nuxi typecheck playground"
+    "test:types": "pnpm dev:prepare && tsc --noEmit && nuxi typecheck playground",
+    "prepare": "pnpm dev:prepare && pnpm run build"
   },
   "dependencies": {
     "autoprefixer": "^10.4.20",

--- a/src/internal-context/load.ts
+++ b/src/internal-context/load.ts
@@ -112,7 +112,7 @@ const createInternalContext = async (moduleOptions: ModuleOptions, nuxt = useNux
             withSrcDir(`{A,a}pp${sfcExtensions}`),
             withSrcDir(`{E,e}rror${sfcExtensions}`),
             withSrcDir(`app.config${defaultExtensions}`),
-            !nuxtOptions.ssr && nuxtOptions.spaLoadingTemplate !== false && withSrcDir(typeof nuxtOptions.spaLoadingTemplate === 'string' ? nuxtOptions.spaLoadingTemplate : 'app/spa-loading-template.html'),
+            !nuxtOptions.ssr && nuxtOptions.spaLoadingTemplate !== false && r(typeof nuxtOptions.spaLoadingTemplate === 'string' ? nuxtOptions.spaLoadingTemplate : 'app/spa-loading-template.html'),
           ].filter((p): p is string => Boolean(p)),
         },
       },


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->
From our chat

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Currently, the path for `spa-loading-template.html` is resolve incorrectly in Nuxt 4 with the latest release (6.12.2).
But I cannot use the nightly (`main`), because there is a regression where class inside `pages` of a layer are not generated.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
