### PR TITLE
fix: only show Tailwind v4 warning when v4 is used

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -50,7 +50,7 @@ export default defineNuxtModule<ModuleOptions>({
 
     const isTailwind4 = await readPackageJSON('tailwindcss', { parent: import.meta.url }).then(m => Number.parseFloat(m.version!) >= 4)
 
-    if (!moduleOptions.experimental?.tailwindcss4) {
+    if (isTailwind4 && !moduleOptions.experimental?.tailwindcss4) {
       logger.warn('Tailwind CSS v4 detected. The current version of `@nuxtjs/tailwindcss` supports Tailwind CSS 3 officially and support for v4 is experimental. To suppress this warning, set `tailwindcss.experimental.tailwindcss4` to  `true` in your `nuxt.config`.')
     }
 


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nuxt-modules/tailwindcss/issues/983

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Check `isTailwind4` before logging the warning so it won't be shown when using v3.

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
