### PR TITLE
fix(docs): add iframe sandbox property as else COOP errors occur

### DIFF
--- a/docs/app/components/content/Sandbox.vue
+++ b/docs/app/components/content/Sandbox.vue
@@ -12,7 +12,7 @@ const colorMode = useColorMode()
       <iframe
         :src="`https://stackblitz.com/github/nuxt-modules/tailwindcss/tree/${props.src}?embed=1&theme=${colorMode.value}`"
         title="Sandbox editor (powered by StackBlitz)"
-        sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"
+        sandbox="allow-modals allow-forms allow-popups allow-popups-to-escape-sandbox allow-scripts allow-same-origin"
         class="w-full h-full min-h-[700px] overflow-hidden bg-gray-100 dark:bg-gray-800"
       />
     </div>


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->
Resolves #987 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
Thank you for contributing to Nuxt!
----------------------------------------------------------------------->

The COOP blocks clicking on "Open in Stackblitz" on the pages.

![image](https://github.com/user-attachments/assets/f50c0623-dd68-43c3-aeb3-ee5dc740cff7)

![image](https://github.com/user-attachments/assets/cc4767aa-0152-4094-a9ad-459cde277e47)

