### PR TITLE
Fixed Spelling Error in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Enable [Tailwind CSS](https://tailwindcss.com) for [Nuxt](https://nuxt.com) тЪбя
 Add `@nuxtjs/tailwindcss` using the [Nuxt CLI](https://github.com/nuxt/cli) to your project
 
 ```bash
-npx nuxi@latest module add tailwindcss
+npx nuxt@latest module add tailwindcss
 ```
 
 <details>


### PR DESCRIPTION
### 🔗 Linked issue

There is a spelling error in README.md.

### ❓ Type of change

I fixed it, because it said nuxi, and I changed it to nuxt.

### 📚 Description

It helps users to use nuxt-tailwind without any errors.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
